### PR TITLE
remove Procfile because heroku will honor npm start by default

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm start


### PR DESCRIPTION
Heroku's node buildpack uses `scripts.start` from package.json in the absence of a Procfile.